### PR TITLE
Update homepage to reflect full-time role at Anthropic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -144,8 +144,6 @@ twitter:
 advised_companies:
  - name: Dropbox
    logo: /images/logos/Dropbox.png
- - name: Anthropic
-   logo: /images/logos/Anthropic.png
  - name: ClickUp
    logo: /images/logos/ClickUp.png
  - name: Eppo

--- a/_config.yml
+++ b/_config.yml
@@ -144,6 +144,8 @@ twitter:
 advised_companies:
  - name: Dropbox
    logo: /images/logos/Dropbox.png
+ - name: Anthropic
+   logo: /images/logos/Anthropic.png
  - name: ClickUp
    logo: /images/logos/ClickUp.png
  - name: Eppo

--- a/index.md
+++ b/index.md
@@ -1,16 +1,16 @@
 ---
 layout: homepage
-title: Alexey Komissarouk | Anthropic
-description: Full-time at Anthropic. Previously Growth Engineering leader at MasterClass and Opendoor. Limited advising availability.
+title: Alexey Komissarouk | Growth Engineering Advisor
+description: Growth at Anthropic. Previously Growth Engineering leader at MasterClass and Opendoor.
 ---
 
 <!-- Hero Section -->
 <section class="hero">
     <!-- Left Column: Main Content -->
     <div class="hero-content">
-        <h1>Hey, I'm Alexey</h1>
-        <div class="tagline">Alexey Komissarouk • Full-time at Anthropic</div>
-        <p>I'm currently full-time at <a href="https://www.anthropic.com">Anthropic</a>. Previously, I spent years leading Growth Engineering organizations at MasterClass and Opendoor, advised dozens of companies and taught over 100 students in my <a href="https://course.alexeymk.com">Growth Eng course</a>. I'm available for advising in a very limited capacity.</p>
+        <h1>Building High-Impact Growth Engineering Teams</h1>
+        <div class="tagline">Alexey Komissarouk • Growth Engineering Advisor</div>
+        <p>Currently doing growth at <a href="https://www.anthropic.com">Anthropic</a>. I've spent years leading Growth Engineering organizations at MasterClass and Opendoor, advised dozens of companies and taught over 100 students in my <a href="https://course.alexeymk.com">Growth Eng course</a>. My advising capacity is limited, but feel free to reach out.</p>
     </div>
     
     <!-- Right Column: Image and CTAs -->
@@ -112,7 +112,7 @@ description: Full-time at Anthropic. Previously Growth Engineering leader at Mas
 
 <!-- Packages Section -->
 <section class="packages">
-    <h2>How I Can Help <span style="font-size: 0.5em; font-weight: normal; opacity: 0.7;">(limited availability)</span></h2>
+    <h2>How I Can Help</h2>
     
     <div class="packages-grid">
         <div class="package">

--- a/index.md
+++ b/index.md
@@ -1,16 +1,16 @@
 ---
 layout: homepage
-title: Alexey Komissarouk | Growth Engineering Advisor
-description: I help companies execute Growth Engineering through a combination of investing, writing and advising.
+title: Alexey Komissarouk | Anthropic
+description: Full-time at Anthropic. Previously Growth Engineering leader at MasterClass and Opendoor. Limited advising availability.
 ---
 
 <!-- Hero Section -->
 <section class="hero">
     <!-- Left Column: Main Content -->
     <div class="hero-content">
-        <h1>Building High-Impact Growth Engineering Teams</h1>
-        <div class="tagline">Alexey Komissarouk • Growth Engineering Advisor</div>
-        <p>I help fast-growing companies build, scale, and hone their Growth Engineering practices. I've spent years leading Growth Engineering organizations at MasterClass and Opendoor, advised dozens of companies and taught over 100 students in my <a href="https://course.alexeymk.com">Growth Eng course</a>.</p>
+        <h1>Hey, I'm Alexey</h1>
+        <div class="tagline">Alexey Komissarouk • Full-time at Anthropic</div>
+        <p>I'm currently full-time at <a href="https://www.anthropic.com">Anthropic</a>. Previously, I spent years leading Growth Engineering organizations at MasterClass and Opendoor, advised dozens of companies and taught over 100 students in my <a href="https://course.alexeymk.com">Growth Eng course</a>. I'm available for advising in a very limited capacity.</p>
     </div>
     
     <!-- Right Column: Image and CTAs -->
@@ -29,7 +29,7 @@ description: I help companies execute Growth Engineering through a combination o
             <a href="mailto:alexey+contact-on-website@alexeymk.com">Contact</a>
         </div>
         <div class="hero-cta">
-            <a href="/growth-eng" class="cta-primary">Work With Me</a>
+            <a href="/growth-eng" class="cta-primary">Growth Eng Advising</a>
         </div>
         
     </div>
@@ -112,7 +112,7 @@ description: I help companies execute Growth Engineering through a combination o
 
 <!-- Packages Section -->
 <section class="packages">
-    <h2>How I Can Help</h2>
+    <h2>How I Can Help <span style="font-size: 0.5em; font-weight: normal; opacity: 0.7;">(limited availability)</span></h2>
     
     <div class="packages-grid">
         <div class="package">

--- a/pages/about.md
+++ b/pages/about.md
@@ -5,7 +5,7 @@ permalink: /about
 ---
 Last updated February 2026.*
 
-These days, I'm full-time at [Anthropic](https://www.anthropic.com) and living in Tokyo. I'm available for [Growth Eng Advising](/growth-eng) in a very limited capacity.
+These days, I'm doing growth at [Anthropic](https://www.anthropic.com) and living in Tokyo. My [advising](/growth-eng) capacity is limited, but feel free to reach out.
 
 #### Growth Engineering Leader
 I spent the last 7 years running Growth Engineering teams, most recently as Head of Growth Engineering at [MasterClass](https://www.masterclass.com), and a Growth EM at [Opendoor](https://www.opendoor.com).  I also teach the [Growth Engineering Course](https://course.aleeymk.com) at Reforge and have worked with over a dozen Growth Engineering clients.

--- a/pages/about.md
+++ b/pages/about.md
@@ -3,9 +3,9 @@ layout: default
 title: About Alexey
 permalink: /about
 ---
-Last updated March 2025.*
+Last updated February 2026.*
 
-These days, I'm living in Tokyo and [doing Growth Eng Advising start-ups scale up their Growth Engineering practice](/growth-eng).
+These days, I'm full-time at [Anthropic](https://www.anthropic.com) and living in Tokyo. I'm available for [Growth Eng Advising](/growth-eng) in a very limited capacity.
 
 #### Growth Engineering Leader
 I spent the last 7 years running Growth Engineering teams, most recently as Head of Growth Engineering at [MasterClass](https://www.masterclass.com), and a Growth EM at [Opendoor](https://www.opendoor.com).  I also teach the [Growth Engineering Course](https://course.aleeymk.com) at Reforge and have worked with over a dozen Growth Engineering clients.


### PR DESCRIPTION
- Hero section now leads with Anthropic full-time status
- Advising positioned as available in very limited capacity
- Removed Anthropic from "Companies I've Helped" (now employer, not client)
- Updated about page intro and date
- CTA changed from "Work With Me" to "Growth Eng Advising"
- Added "(limited availability)" note to packages section

https://claude.ai/code/session_01JbtqBToQ46LVHbkf38usxr